### PR TITLE
Use Latin-1 encoding to avoid freeze on download start

### DIFF
--- a/ircapp/download.py
+++ b/ircapp/download.py
@@ -315,7 +315,7 @@ def xdcc(data, filename="", resume=False):
     down.save()
     size, server, channel, xdccbot, xdccrequest = data.split(",")
     msg = "xdcc send #%s" % xdccrequest
-    irc.client.ServerConnection.buffer_class = irc.buffer.LenientDecodingLineBuffer
+    irc.client.ServerConnection.buffer_class.encoding = 'latin-1';
     c = DCCReceive(xdccbot, msg, channel, size, filename)
     #anonymous nickname
     nickname = ''.join(random.choice(string.ascii_lowercase) for i in range(8))


### PR DESCRIPTION
When testing out the Dockerfile in https://github.com/themadmrj/ircapp/pull/2 I ran into a strange issue. Whenever I start a download IRCapp freezes on `irc.client.ServerConnection.buffer_class = irc.buffer.LenientDecodingLineBuffer`, [see the line here.](https://github.com/themadmrj/ircapp/blob/master/ircapp/download.py#L318) I'm using the latest irc [14.2.2](https://github.com/jaraco/irc/releases/tag/14.2.2). I'm not sure exactly what the issue is but changing the encoding to `Latin-1` fixes the problem for me.
