### PR TITLE
Add support for XDCC queues

### DIFF
--- a/ircapp/download.py
+++ b/ircapp/download.py
@@ -76,8 +76,8 @@ class DCCReceive(irc.client.SimpleIRCClient):
         self.hist = hist
         self.cancel = False
         self.position = 0
+        self.queued = False
 
-                
     def stop(self, connection):
         while Download_Ongoing.objects.get(id=down.id).active == True:
             time.sleep(0.5)
@@ -88,6 +88,11 @@ class DCCReceive(irc.client.SimpleIRCClient):
         elif Download_Ongoing.objects.get(id=down.id).status == "Shutdown":
             log("Download interrupted by a user shutdown/restart").write()
         self.cancel = True
+        if connection.connected and self.queued:
+            # We don't want to leave dangling queues on cancellation.
+            self.queued = False
+            log("Removing from XDCC queue").write()
+            connection.privmsg(self.bot, "XDCC REMOVE")
         self.reactor.disconnect_all()
         return ""
 
@@ -96,8 +101,11 @@ class DCCReceive(irc.client.SimpleIRCClient):
     def retry_pack(self, connection):
         if self.received_bytes == 0:
             if connection.connected:
-                connection.privmsg(self.bot, self.msg)
-                log("Package requested again").write()
+                if self.queued:
+                    log("Waiting in XDCC bot's queue").write()
+                else:
+                    connection.privmsg(self.bot, self.msg)
+                    log("Package requested again").write()
 
     def on_welcome(self, connection, event):
         connection.join(self.channel)
@@ -107,7 +115,7 @@ class DCCReceive(irc.client.SimpleIRCClient):
             log("Channel #mg-chat joined to be able to download").write()
         connection.privmsg(self.bot, self.msg)
         log("Channel joined (%s) and package requested" % self.channel).write()
-        down.status, down.sizeraw = "Waiting for package (in queue)...", self.size
+        down.status, down.sizeraw = "Waiting for package (in IRCapp queue)...", self.size
         down.save()
         s=threading.Timer(60.0, self.retry_pack, [connection])
         s.daemon=True
@@ -157,6 +165,8 @@ class DCCReceive(irc.client.SimpleIRCClient):
     def process(self, c, e, resume=False):
         #"When receiving a file with DCC, accept it"
         downloads_dir = directory()
+        # No longer queued, if download stalls here it's an actual problem.
+        self.queued = False
 
         if resume:
             self.file = open(os.path.join(downloads_dir, self.filename), 'ab')
@@ -243,6 +253,11 @@ class DCCReceive(irc.client.SimpleIRCClient):
             self.hist.save()
 
             log("Discarding download due to invalid pack number, proceeding to next item in queue if existing.").write()
+        if "all slots full" in str(a).lower():
+            self.queued = True
+            log("Added to XDCC bot's queue").write()
+            down.status = "Waiting for package (in XDCC bot queue)..."
+            down.save()
 
     def on_dccchat(self, c, e):
         log("dccchat").write()
@@ -287,7 +302,9 @@ def DCC_deamonthread(c, server, nickname, hist, down):
     try:
         c.connect(server, 6667, nickname)
         c.start()
-    except irc.client.ServerConnectionError as x:
+    # On Mac OS irc's process_once() seems to throw OSError: [Errno 9] Bad file descriptor
+    # during disconnect, we can just suppress the error here but we should log.
+    except (irc.client.ServerConnectionError, OSError) as x:
         log("error" + str(x)).write()
         hist.status, hist.time, hist.sizeraw = "Error during connection", utcnow(), size
         hist.save()

--- a/templates/search.html
+++ b/templates/search.html
@@ -786,7 +786,7 @@ function Monitor() {
 	  }
 	  //8 = empty
 
-	  if ( response.fields.status.indexOf("queue") >= 0 ){
+	  if ( response.fields.status.indexOf("IRCapp queue") >= 0 ){
 	    if ( queue_counter === 0 ){
 	      Mycounter = setInterval( Queue_Counter, 1000);
 	    } else {
@@ -808,7 +808,8 @@ function Monitor() {
                 }
             } else {
                 //in this case, the item is in queue for 30 seconds for the first time
-	            if ($('#queue table').children().length > 0 ){
+	            var inBotQueue = response.fields.status.indexOf("XDCC bot queue") >= 0;
+		    if ($('#queue table').children().length > 0 && !inBotQueue) {
 		        //move the item to the end of the queue and start next download
 		        $.ajax({
 		          url: "/cancel_download/",


### PR DESCRIPTION
I ran into an additional issue. Some content is only available on archive or request bots. These bots are usually very busy and almost always force you to wait in queue. Currently `IRCapp` will wait 30 seconds before cancelling a download and re-queuing if it doesn't start before then. This behaviour effectively means that `IRCapp` will never make any progress in the queue. Moreover, it will keep flooding bots with secondary requests for the same file even though the pack is already queued.

This patch adds functionality to wait indefinitely in queue, and adds a new state text so the user can decide if they want to cancel the download by distinguishing between an `IRCapp queue` and an `XDCC bot queue` in the UI.
