### PR TITLE
Display log through web browser

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -84,7 +84,7 @@
     <a class="opacity-on-hover" target="_blank" href="http://www.getmdl.io/"><img height="18px" src="{{STATIC_URL}}ic_mdl_gray.svg"></a>
   </div>
   <div class="mdl-card__actions mdl-card--border">
-    <a id="report_bug" href="https://sourceforge.net/p/ircapp/tickets/" class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect">
+    <a id="report_bug" href="https://github.com/themadmrj/ircapp/issues" class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect">
       Report bug
     </a>
     <a href="bitcoin:1KTXsH5D7nG9vozmWb3WkbBJrPnwsEieis" class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect">

--- a/templates/search.html
+++ b/templates/search.html
@@ -74,7 +74,7 @@
   <!-- </div> -->
   <div style="text-align:center;padding-top:60px" class="mdl-card__supporting-text">
     <img style="margin-right:8px;margin-bottom:8px" src="{{STATIC_URL}}ic_ircapp_logo_bluegray.svg" height="32px"><br>
-    v<strong>1.1.1</strong> &middot; <a style="text-decoration:underline;cursor:pointer;" target="_blank" id="log">Log file</a><br><br>
+    v<strong>1.1.1</strong> &middot; <a style="text-decoration:underline;cursor:pointer;" target="_blank" href="/log/">Log file</a><br><br>
     <strong>Code by MrJ &middot; Art by Schickele</strong><br>
     Inspired by the search king’s dev site<br>
     &copy; 2015 &middot; <a target="_blank" href="{{STATIC_URL}}ircapp_gua.txt">License (MIT)</a><br><br>
@@ -356,9 +356,6 @@ $('#about_button').click(function(event) {
     $("#down").hide();
     $("#settings_div").hide();
   }
-});
-$('#log').click(function(event) {
-  $.get( "/log/" );
 });
 
 /// now comes the rest

--- a/views.py
+++ b/views.py
@@ -124,15 +124,10 @@ def delete_pref(request):
         return HttpResponse("")
 
 def read_log(request):
-    if sys.platform == "win32":
-        os.startfile(log().my_log)
-    else:
-        opener ="open" if sys.platform == "darwin" else "xdg-open"
-        subprocess.call([opener, log().my_log])
-    return HttpResponse("")
-
-    
-    
+    log_file = open(log().my_log)
+    response = HttpResponse(content=log_file)
+    response['Content-Type'] = 'text/plain'
+    return response
     
 def index(request):
 


### PR DESCRIPTION
I'm running IRCapp on a remote server, so the current `read_log` code cannot work, because I'm accessing it remotely. This patch displays the log in a new web browser window. Functionality when running locally is not affected negatively since you won't want to edit the log in a (default) text editor anyway.

I also changed the issue reporting link to Github since Sourceforge is pretty dead. :P
